### PR TITLE
.gitconfig にゴミが残ってしまう問題を解決

### DIFF
--- a/hal_osaka_proxy.sh
+++ b/hal_osaka_proxy.sh
@@ -11,6 +11,8 @@ password=認証PW
 git config --global --unset http.proxy
 git config --global --unset https.proxy
 git config --global --unset url."https://".insteadOf
+sed -i '' -e '/http/d' ~/.gitconfig
+sed -i '' -e '/https/d' ~/.gitconfig
 
 # npm
 npm -g config delete proxy


### PR DESCRIPTION
### 解決したいこと

現状の記述だと、`git config --global --unset <proxy>` の際、 `.gitconfig` に `[http]` 等が残った状態となってしまう。
この状態で再度 `git config --global http.proxy <proxy>` を実行すると、前回の `[http]` 等とは別に記述されてしまう。

### 解決策

`sed` コマンドで削除する

### 難点

他の `[http]` の設定がある場合、困る。